### PR TITLE
fix: update broken links

### DIFF
--- a/essays/fixing-unix-linux-filenames.html
+++ b/essays/fixing-unix-linux-filenames.html
@@ -585,7 +585,7 @@ can begin with a hyphen (which are then expanded by wildcards).
 I am really glad that Juranic is making more people aware of the problem!
 However, this is not new information;
 these types of vulnerabilities have been known for decades.
-<a href="http://www.net-security.org/article.php?id=2061">Kucan comments
+<a href="https://www.helpnetsecurity.com/2014/06/27/exploiting-wildcards-on-linux/">Kucan comments
 on this</a>, noting that this particular vulnerability can be
 countered by always beginning wildcards with &#8220;./&#8221;.
 This is true, and
@@ -699,13 +699,13 @@ in filenames</a>, and there&#8217;s no consensus that it even <i>should</i>.
 <li><a href="http://www.mail-archive.com/bug-cvs@gnu.org/msg05255.html">
 Some versions of CVS fail if filenames have newlines</a>.
 <li>Key security program
-<a href="http://osdir.com/ml/version-control.monotone.devel/2003-11/msg00045.html">sha1sum performs odd undocumented behavior when certain
+<a href="https://lists.gnu.org/archive/html/monotone-devel/2003-11/msg00045.html">sha1sum performs odd undocumented behavior when certain
 odd characters (like newline) are in filenames</a> &mdash; here
 there&#8217;s an attempt to handle odd filenames,
 but because it&#8217;s an undocumented and non-standard result,
 it can make the problem <i>worse</i>.
 <li>A Fedora discussion on
-<a href="http://forums.fedoraforum.org/archive/index.php/t-166962.html">
+<a href="https://forums.fedoraforum.org/showthread.php?166962-How-to-iterate-over-files-in-a-bash-script">
 &#8220;How to iterate over files in a bash script?&#8221;</a> discussed this; the
 author used &#8220;while read FILENAME&#8221;, which has the errors noted above
 (fails on filenames with newlines, leading/trailing whitespace, or
@@ -813,7 +813,7 @@ its filenames can only contain printable characters
 (that is, any character outside hexadecimal 00-1F and 80-9F) and cannot
 include either slash or blank
 (per intro(5)).
-<a href="http://9fans.net/archive/1998/04/22">Tom Duff explains why
+<a href="https://marc.info/?l=9fans&m=111558704918871">Tom Duff explains why
 Plan 9 filenames with spaces</a> are a pain
 for many reasons, in particular, that they mess up scripts.
 Duff said,
@@ -1081,7 +1081,7 @@ make <i>some</i> determination... and it will be wrong.
 The traditional POSIX approach is to use environment variables that declare
 the filename character encoding
 (such as
-<a href="http://opengroup.org/onlinepubs/007908799/xbd/envvar.html">LC_ALL,
+<a href="https://pubs.opengroup.org/onlinepubs/007908799/xbd/envvar.html">LC_ALL,
 LC_CTYPE, LC_CTYPE, LC_COLLATE, and LANG</a>).
 But as soon as you start working with other people
 (say, by receiving a tarball or sharing a filesystem),
@@ -1096,7 +1096,7 @@ KOI8-* (for Cyrillic)? EUC-JP or Shift-JIS (both popular in Japan)?
 In short, this is too flexible!
 Since people routinely share information around the world, this
 incompatibility is awful.
-<a href="http://www.opengroup.org/platform/single_unix_specification/show_mail.tpl?CALLER=index.tpl&amp;source=L&amp;listname=austin-group-l&amp;id=12033&amp;listid=austin-group-l">
+<a href="https://collaboration.opengroup.org/tech/austin/plato/mailarch.php?archive=austin-group-l&amp;action=show&num=12033">
 The Austin Group even had a discussion about this in 2009</a>.
 This failure to standardize the encoding leads to confusion, which can lead to
 mistakes and even vulnerabilities.
@@ -1260,7 +1260,7 @@ is a design error:
 Unix, and made it explicit in its system interfaces that these data
 (file names, environment variables, command line arguments) are indeed
 character data [and not arbitrary bytes]&#8221;.
-<a href="http://mail.python.org/pipermail/python-list/2009-April/710719.html">
+<a href="https://mail.python.org/archives/list/python-list@python.org/message/IWCPRXIIAQ7GUK4Q63QGD77QYN2GT3HJ/">
 Zooko O&#8217;Whielacronx posted 
 some comments on Python PEP 383 relating to the Tahoe project</a>.
 He commented separately to me that
@@ -1306,7 +1306,7 @@ unreasonable limitations.
 <p>
 Linux distributions are already moving towards storing filenames in UTF-8,
 for this very reason.
-<a href="http://fedoraproject.org/wiki/Packaging/Guidelines#Non-ASCII_Filenames">Fedora&#8217;s packaging guidelines</a> require that
+<a href="https://docs.fedoraproject.org/en-US/packaging-guidelines/#_non_ascii_filenames">Fedora&#8217;s packaging guidelines</a> require that
 &#8220;filenames that contain non-ASCII characters must be encoded as
 UTF-8. Since there&#8217;s no way to note which encoding the filename is in,
 using the same encoding for all filenames is the best way to ensure
@@ -1329,7 +1329,7 @@ The major POSIX GUI suites GNOME and KDE have already moved towards UTF-8
 as the required filename encoding format:
 <ol>
 <li>In a 2003 discussion about GNOME,
-<a href="http://osdir.com/ml/gnome.vfs.general/2003-03/msg00014.html">
+<a href="https://mail.gnome.org/archives/gnome-vfs-list/2003-March/msg00014.html">
 Michael Meeks</a> noted that
 &#8220;using locale encoded filenames on the disk is a really,
 really bad idea :-) simply because there is never sufficient information
@@ -1341,7 +1341,7 @@ the whole Unix world needs fixing to be UTF-8 happy...&#8221;
 <li>KDE has this problem, too.
 They do their best to deal with it by guessing from the user&#8217;s locale,
 but they also have the option
-<a href="http://techbase.kde.org/KDE_System_Administration/Environment_Variables#KDE_UTF8_FILENAMES">KDE_UTF8_FILENAMES</a> so that
+<a href="https://userbase.kde.org/KDE_System_Administration/Environment_Variables#KDE_UTF8_FILENAMES">KDE_UTF8_FILENAMES</a> so that
 UTF-8-everywhere filesystems are easily handled.
 <a href="http://www.andlinux.org/forum/viewtopic.php?t=310">This note
 may be of interest too</a>.
@@ -2177,7 +2177,7 @@ particularly on Mac OS X, Windows, and remote filesystems (e.g., via NFS).
 <p>
 The
 <a href="http://git-blame.blogspot.com.es/2014/12/git-1856-195-205-214-and-221-and.html">git developers fixed a critical vulnerability in late 2014</a>
-(<a href="http://article.gmane.org/gmane.linux.kernel/1853266">CVE-2014-9390</a>) due to filenames.
+(<a href="https://lore.kernel.org/git/xmqq61d87jew.fsf@gitster.dls.corp.google.com/">CVE-2014-9390</a>) due to filenames.
 <a href="https://github.com/blog/1938-vulnerability-announced-update-your-git-clients">GitHub has an interesting post about it</a>.
 Mercurial had the same problem (they notified the git developers about it).
 In particular, filenames that appear different are considered the same:
@@ -3461,7 +3461,7 @@ its
 <a href="http://msdn.microsoft.com/en-us/library/ktss1a9b%28v=vs.80%29.aspx">
 distinction between binary and text files</a> <a href="  http://msdn.microsoft.com/en-us/library/yeby3zcb%28v=vs.80%29.aspx">*</a>,
 its monolithic design, and
-the <a href="http://www.codinghorror.com/blog/archives/000939.html">
+the <a href="https://blog.codinghorror.com/was-the-windows-registry-a-good-idea/">
 Windows registry</a>.
 Any real-world system has <i>some</i> problems, but the POSIX/Linux
 filename issues <i>can</i>


### PR DESCRIPTION
In only “[Fixing Unix/Linux/POSIX Filenames](https://dwheeler.com/essays/fixing-unix-linux-filenames.html)”:

- replace old and broken URLs with their new addresses, but
- skip content that appears permanently gone