### PR TITLE
fix: replace dead links with Internet Archive copies

### DIFF
--- a/essays/fixing-unix-linux-filenames.html
+++ b/essays/fixing-unix-linux-filenames.html
@@ -30,7 +30,7 @@ No! Life is not so simple. There is reason to think that constraints
 (prohibitions, if you like) can actually help people to do things
 better. Constraints can enhance ability...&#8221;
 <!-- ;in other words, less negative freedom can mean more positive freedom. -->
-&mdash; <a href="http://www.equilibrium-economicum.net/twokindsoffreedom.htm">
+&mdash; <a href="https://web.archive.org/web/20200915003102/http://www.equilibrium-economicum.net/twokindsoffreedom.htm">
  Angus Sibley, &#8220;Two Kinds of Freedom&#8221;</a>
 <br><br>
 &#8220;...filesystem people should aim to make &#8220;badly written&#8221; code
@@ -554,7 +554,7 @@ In some cases, these errors can even be security vulnerabilities.
 My <a href="https://dwheeler.com/secure-programs/Secure-Programs-HOWTO/file-names.html">&#8220;Secure Programming for Linux and Unix HOWTO&#8221; has
 a section dedicated to vulnerabilities caused by filenames</a>.
 Similarly,
-<a href="https://www.securecoding.cert.org/confluence/display/seccode/MSC09-C.+Character+Encoding+-+Use+Subset+of+ASCII+for+Safety">
+<a href="https://web.archive.org/web/20161225044728/https://www.securecoding.cert.org/confluence/display/c/MSC09-C.+Character+encoding%3A+Use+subset+of+ASCII+for+safety">
 CERT&#8217;s &#8220;Secure Coding&#8221; item MSC09-C
 (Character Encoding &mdash; Use Subset of ASCII for Safety)</a>
 specifically discusses the vulnerabilities due to filenames.
@@ -579,7 +579,7 @@ that can be triggered by malicious filenames.
 These types of vulnerabilities occasionally get rediscovered, too.
 For example,
 Leon Juranic released in 2014 an essay titled
-<a href="http://www.defensecode.com/public/DefenseCode_Unix_WildCards_Gone_Wild.txt">Back to the Future: Unix Wildcards Gone Wild</a>,
+<a href="https://web.archive.org/web/20220123120818/https://www.defensecode.com/public/DefenseCode_Unix_WildCards_Gone_Wild.txt">Back to the Future: Unix Wildcards Gone Wild</a>,
 which demonstrates some of the problems that can be caused because filenames
 can begin with a hyphen (which are then expanded by wildcards).
 I am really glad that Juranic is making more people aware of the problem!
@@ -627,7 +627,7 @@ loathed by many (for an explanation, see
 Now, it&#8217;s true that some issues are innate to the Bourne shell,
 and cannot be fixed by limiting filenames.
 The
-<a href="http://www.computerworld.com.au/article/279011/-z_programming_languages_bourne_shell_sh">
+<a href="https://web.archive.org/web/20180624070706/https://www.computerworld.com.au/article/279011/-z_programming_languages_bourne_shell_sh">
 Bourne shell</a> is actually a nice programming language for what it is for,
 but as noted by Bourne himself, its design requirements led to compromises
 that can sometimes be irksome.
@@ -663,7 +663,7 @@ processing; it&#8217;d be nice to be able to easily use that with filenames.
 <p>
 The problem of awkward filenames is so bad that there are programs like
 <a href="http://linux.die.net/man/1/detox">detox</a> and
-<a href="http://www.glindra.org/doc/cleanup">Glindra</a> that try to
+<a href="https://web.archive.org/web/20150208200247/http://www.glindra.org/doc/cleanup.html">Glindra</a> that try to
 fix &#8220;bad&#8221; filenames.
 The POSIX standard includes
 <a href="http://www.gnu.org/software/coreutils/manual/html_node/pathchk-invocation.html">pathchk</a>; this lets you determine that a filename is bad.
@@ -687,7 +687,7 @@ no point in supporting such filenames!
 For example:
 <ul>
 <li>
-<a href="http://unix.derkeiler.com/Newsgroups/comp.unix.shell/2006-03/msg01221.html">John DuBois stated on 2006-03-27</a> that
+<a href="https://web.archive.org/web/20200526035340/http://unix.derkeiler.com/Newsgroups/comp.unix.shell/2006-03/msg01221.html">John DuBois stated on 2006-03-27</a> that
 &#8220;Newlines in filenames are mainly something you would encounter in a malicious
 context &mdash; created by a local user, included in an archive, etc. Since I don&#8217;t
 expect to ever see a *useful* file with a newline embedded in its name, and
@@ -710,10 +710,10 @@ it can make the problem <i>worse</i>.
 author used &#8220;while read FILENAME&#8221;, which has the errors noted above
 (fails on filenames with newlines, leading/trailing whitespace, or
 including a backslash).
-<li><a href="http://ramblings.narrabilis.com/wp/looping-through-files-with-spaces-in-the-names-in-bash/">Here&#8217;s another example of people genuinely trying
+<li><a href="https://web.archive.org/web/20120622073409/http://ramblings.narrabilis.com/wp/looping-through-files-with-spaces-in-the-names-in-bash/">Here&#8217;s another example of people genuinely trying
 to help each other</a>, again with an incorrect &#8220;while read FILENAME&#8221;
 solution.
-<li><a href="http://calypso.tux.org/pipermail/novalug/2009-February/017524.html">
+<li><a href="https://web.archive.org/web/20110917024019/http://calypso.tux.org/pipermail/novalug/2009-February/017524.html">
 Michael Henry&#8217;s Novalug post
 &#8220;Filename handling: correctness vs. convenience&#8221;
 (2009-02-28)</a>
@@ -869,7 +869,7 @@ it&#8217;d be better to make the no-newline assumption true in the first place!
 I know of <i>no</i> program that legitimately requires the ability to
 insert newlines in a filename.
 Indeed, it&#8217;s not hard to find comments like
-&#8220;<a href="http://unix.derkeiler.com/Newsgroups/comp.unix.shell/2006-03/msg00484.html">ban newlines in filenames</a>&#8221;.
+&#8220;<a href="https://web.archive.org/web/20200526034350/http://unix.derkeiler.com/Newsgroups/comp.unix.shell/2006-03/msg00484.html">ban newlines in filenames</a>&#8221;.
 GNU&#8217;s &#8220;find&#8221; and &#8220;xargs&#8221; make it possible to work around this by
 inserting byte 0 between each filename... but few other programs support this
 convention (even &#8220;ls&#8221; normally doesn&#8217;t, and most
@@ -1227,7 +1227,7 @@ Python 3 moved to a very clean system where there are &#8220;string&#8221; types
 handle internationalized text and &#8220;bytes&#8221; that contain arbitrary data.
 You would think that filenames would be string types, but currently
 POSIX filenames are really just binary blobs!
-<a href="http://docs.python.org/dev/3.0/whatsnew/3.0.html">
+<a href="https://web.archive.org/web/20100413185408/http://docs.python.org/dev/3.0/whatsnew/3.0.html">
 Python 3&#8217;s &#8220;what&#8217;s new&#8221;</a> discusses what they had to do in trying
 to paper this over, but as epa says, this situation
 interferes with implementing filenames
@@ -1311,7 +1311,7 @@ for this very reason.
 UTF-8. Since there&#8217;s no way to note which encoding the filename is in,
 using the same encoding for all filenames is the best way to ensure
 users can read the filenames properly.&#8221;
-<a href="http://en.opensuse.org/SDB:Converting_Files_or_File_Names_to_UTF-8_Encoding">OpenSuSE 9.1</a> has already switched to using UTF-8 as the default
+<a href="https://web.archive.org/web/20090509144349/http://en.opensuse.org/SDB:Converting_Files_or_File_Names_to_UTF-8_Encoding">OpenSuSE 9.1</a> has already switched to using UTF-8 as the default
 system character set (&#8220;lang_LANG.UTF-8&#8221;).
 <a href="https://help.ubuntu.com/community/LocaleConf">Ubuntu recommends
 using UTF-8</a>, saying &#8220;A good rule is to choose utf-8 locales&#8221;,
@@ -1343,7 +1343,7 @@ They do their best to deal with it by guessing from the user&#8217;s locale,
 but they also have the option
 <a href="http://techbase.kde.org/KDE_System_Administration/Environment_Variables#KDE_UTF8_FILENAMES">KDE_UTF8_FILENAMES</a> so that
 UTF-8-everywhere filesystems are easily handled.
-<a href="http://www.andlinux.org/forum/viewtopic.php?t=310">This note
+<a href="https://web.archive.org/web/20101205103906/http://www.andlinux.org/forum/viewtopic.php?t=310">This note
 may be of interest too</a>.
 </ol>
 
@@ -2117,7 +2117,7 @@ as you&#8217;ve considered all possible cases.
 <p>
 In fact, for portability&#8217;s sake, you already don&#8217;t want to create
 filenames with weird characters either.
-<a href="http://www.xvsxp.com/files/forbidden.php">MacOS and Windows XP
+<a href="https://web.archive.org/web/20100221212141/http://www.xvsxp.com/files/forbidden.php">MacOS and Windows XP
 also forbid certain characters/names</a>.
 Some MacOS filesystems and interfaces
 forbid &#8220;:&#8221; in a name (it&#8217;s the directory separator).
@@ -2598,8 +2598,8 @@ will cause <i>catastrophic</i> effects, because they will be executed
 (unescaped!) by another shell.
 <p>
 Paul Dunne&#8217;s review of the &#8220;Unix Hater&#8217;s Handbook&#8221;
-(<a href="http://www.kuro5hin.org/story/2000/10/20/24336/134">here</a> and
-<a href="http://www.linuxlots.com/~dunne//review.the_unix_haters_handbook.html">
+(<a href="https://web.archive.org/web/20140929184626/http://www.kuro5hin.org/story/2000/10/20/24336/134">here</a> and
+<a href="https://web.archive.org/web/20090413175226/http://linuxlots.com/~dunne/review.the_unix_haters_handbook.html">
 here</a>)
 proposes a solution, but his solution is both
 <i>wrong</i> and <i>complicated</i>.
@@ -2724,7 +2724,7 @@ more easily scales to more complicated file processing.
 
 <p>
 Similarly, here is a little script called
-<a href="https://dwheeler.com/misc/mklowercase">mklowercase</a>,
+<a href="https://web.archive.org/web/20200915003110/https://dwheeler.com/misc/mklowercase">mklowercase</a>,
 which renames all filenames to lowercase recursively from
 the current directory (&#8220;.&#8221;) down.
 Again, this script is pretty simple to write
@@ -3487,7 +3487,7 @@ and whether or not to enforce UTF-8.
 All that&#8217;s needed in the kernel is a mechanism to enforce such a policy.
 After all, the problem is so bad that there are programs like
 <a href="http://linux.die.net/man/1/detox">detox</a> and
-<a href="http://www.glindra.org/doc/cleanup">Glindra</a> to fix bad filenames.
+<a href="https://web.archive.org/web/20150208200247/http://www.glindra.org/doc/cleanup.html">Glindra</a> to fix bad filenames.
 
 
 <p>


### PR DESCRIPTION
In only “[Fixing Unix/Linux/POSIX Filenames](https://dwheeler.com/essays/fixing-unix-linux-filenames.html)”:

- replace content that appears permanently offline with Wayback Machine copies