### PR TITLE
feat: replace broken link with applicable video

### DIFF
--- a/essays/fixing-unix-linux-filenames.html
+++ b/essays/fixing-unix-linux-filenames.html
@@ -1269,7 +1269,7 @@ costly storage of &#8216;which encoding was allegedly used&#8217; next
 to *every*
 filename if we instead required utf-8b for all filenames on Linux.&#8221;
 (Sidebar: Tahoe is an interesting project;
-<a href="http://testgrid.allmydata.org:3567/uri/URI:DIR2-RO:j74uhg25nwdpjpacl6rkat2yhm:kav7ijeft5h7r7rxdp5bgtlt3viv32yabqajkrdykozia5544jqa/wiki.html">
+<a href="https://www.youtube.com/watch?v=ztbIwH7gz7o">
 Here is Zooko smashing a laptop with an axe as part of his Tahoe
 presentation</a>.)
 


### PR DESCRIPTION
Zooko’s blog, now [here](https://tahoe-lafs.org/~warner/blog.html),[^1] linked to a Flash version of [this YouTube video](https://www.youtube.com/watch?v=ztbIwH7gz7o).

If instead of linking directly to a YouTube-hosted video, we wished to link to blog post-type content that itself has a link to the YouTube video, a good choice would be [this contemporary, but still online, mailing list message from Zooko](https://lists.lug.boulder.co.us/pipermail/lug/Week-of-Mon-20090420/038224.html) ([archive](https://web.archive.org/web/20260524004120/https://lists.lug.boulder.co.us/pipermail/lug/Week-of-Mon-20090420/038224.html)).

This is a separate pull request from [#3](https://github.com/david-a-wheeler/david-a-wheeler.github.io/pull/3) and [#4](https://github.com/david-a-wheeler/david-a-wheeler.github.io/pull/4) because it replaces one type of content (blog for blog post) with another (video).

[^1]: The blog _post_ has no permalink and had no permalink at [the blog’s old location](https://web.archive.org/web/20100209183858/http://testgrid.allmydata.org:3567/uri/URI:DIR2-RO:j74uhg25nwdpjpacl6rkat2yhm:kav7ijeft5h7r7rxdp5bgtlt3viv32yabqajkrdykozia5544jqa/wiki.html).